### PR TITLE
Set github-actions-bot as an author

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,10 +7,7 @@ if [ ! -n "$GITHUB_TOKEN" ]; then
   echo "You need to supply GITHUB_TOKEN"
 fi
 
-git config user.name "${GITHUB_ACTOR}"
-git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-
-gh-pages -d $PUBLIC_PATH -b gh-pages
+gh-pages -d $PUBLIC_PATH -b gh-pages -u "github-actions-bot <support+actions@github.com>"
 
 curl --request POST -H "Authorization: token ${GITHUB_TOKEN}" \
   --url "https://api.github.com/repos/$GITHUB_REPOSITORY/pages/builds" \


### PR DESCRIPTION
Set `github-actions-bot` as an author for several reasons:

1. `git config user.name "username"` makes a change in `/github/workspace/.git/config`. The file is shared with other GitHub Actions in the same workflow. It'd better not to make side effects as possible.

1. Pre-defined `GITHUB_TOKEN` is not the user's token, but `github-action[bot]`'s. This can be confirmed by the following graphql.
    ```graphql
    {
      viewer {
        login
      }
    }
    ```
1. Buy the above reason, whatever `GITHUB_ACTOR` is, the actor of the push activity is `github-actions[bot]`.
![capture](https://user-images.githubusercontent.com/880189/50545143-4a4baf80-0c4d-11e9-984c-2d05c01d0f60.PNG)
This also can be confirmed by the following api:
https://developer.github.com/v3/activity/events/#list-public-events-that-a-user-has-received

1. `GITHUB_ACTOR` is *login id*, and this is different with author of other commits, *user name*. Inconsistency occurs. In addition, it's not able to change email.

1. The default author of travis alternative is a bot.
https://docs.travis-ci.com/user/deployment/pages/#further-configuration

