### PR TITLE
Add provision to push to any branch instead of gh-pages

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ ! -n "$GITHUB_TOKEN" ]; then
   echo "You need to supply GITHUB_TOKEN"
   exit 1
 fi
-gh-pages -d $PUBLIC_PATH -b $PUSH_BRANCH -u "github-actions-bot <support+actions@github.com>"
+gh-pages -d $PUBLIC_PATH -b $PUSH_BRANCH -u "dgr8akki <pahujaaakash5@gmail.com>"
 retval=$?
 if [ $retval -ne 0 ]; then
   echo "gh-pages failed: $retval"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,11 +3,14 @@
 if [ ! -n "$PUBLIC_PATH" ]; then
   PUBLIC_PATH=public
 fi
+if [ ! -n "$PUSH_BRANCH" ]; then
+  PUSH_BRANCH=gh-pages
+fi
 if [ ! -n "$GITHUB_TOKEN" ]; then
   echo "You need to supply GITHUB_TOKEN"
   exit 1
 fi
-gh-pages -d $PUBLIC_PATH -b gh-pages -u "github-actions-bot <support+actions@github.com>"
+gh-pages -d $PUBLIC_PATH -b $PUSH_BRANCH -u "github-actions-bot <support+actions@github.com>"
 retval=$?
 if [ $retval -ne 0 ]; then
   echo "gh-pages failed: $retval"


### PR DESCRIPTION
Add a provision to push to any branch instead of the gh-pages with the help of github secrets.

Default Branch: gh-pages